### PR TITLE
 Return error in case of missing OwnerRef on AgentMachin

### DIFF
--- a/controllers/agentcluster_controller.go
+++ b/controllers/agentcluster_controller.go
@@ -117,6 +117,7 @@ func (r *AgentClusterReconciler) updateAgentClusterInstall(ctx context.Context, 
 			Url:           url[0:strings.LastIndex(url, "/")],
 			CaCertificate: agentCluster.Spec.IgnitionEndpoint.CaCertificate,
 		}
+		log.Infof("Updated Ignition URL: %s", agentClusterInstall.Spec.IgnitionEndpoint.Url)
 		updateACI = true
 	}
 	if updateACI {

--- a/controllers/agentmachine_controller.go
+++ b/controllers/agentmachine_controller.go
@@ -145,7 +145,7 @@ func (r *AgentMachineReconciler) findAgent(ctx context.Context, log logrus.Field
 	agentMachine.Status.Addresses = machineAddresses
 	agentMachine.Status.Ready = false
 	if err := r.setIgnitionEndpointToken(ctx, log, foundAgent, agentMachine); err != nil {
-		log.WithError(err).Error("failed getting information on ignition endpoint")
+		log.WithError(err).Warn("failed getting information on ignition endpoint")
 		return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, err
 	}
 
@@ -169,13 +169,11 @@ func (r *AgentMachineReconciler) setIgnitionEndpointToken(ctx context.Context, l
 		return err
 	}
 	if machine == nil {
-		log.Info("Waiting for Machine Controller to set OwnerRef on AgentMachine")
-		return nil
+		return errors.New("waiting for Machine Controller to set OwnerRef on AgentMachine")
 	}
 
 	if machine.Spec.Bootstrap.DataSecretName == nil {
-		log.Info("No DataSecretName set, not setting ignition endpoint token")
-		return nil
+		return errors.New("no DataSecretName set, not setting ignition endpoint token")
 	}
 
 	secret := &corev1.Secret{}

--- a/controllers/agentmachine_controller.go
+++ b/controllers/agentmachine_controller.go
@@ -159,6 +159,7 @@ func (r *AgentMachineReconciler) findAgent(ctx context.Context, log logrus.Field
 }
 
 func (r *AgentMachineReconciler) setIgnitionEndpointToken(ctx context.Context, log logrus.FieldLogger, agent *aiv1beta1.Agent, agentMachine *capiproviderv1alpha1.AgentMachine) error {
+	log.Info("Setting Ignition endpoint info")
 	if agent.Spec.IgnitionEndpointToken != "" {
 		log.Info("Ignition endpoint token already set, not updating it")
 		return nil
@@ -197,6 +198,7 @@ func (r *AgentMachineReconciler) setIgnitionEndpointToken(ctx context.Context, l
 
 	ignitionSource := ignitionConfig.Ignition.Config.Merge[0]
 	agent.Spec.MachineConfigPool = (*ignitionSource.Source)[strings.LastIndex((*ignitionSource.Source), "/")+1:]
+	log.Infof("Setting MachineConfigPool to %s", agent.Spec.MachineConfigPool)
 
 	for _, header := range ignitionSource.HTTPHeaders {
 		if header.Name != "Authorization" {
@@ -207,6 +209,7 @@ func (r *AgentMachineReconciler) setIgnitionEndpointToken(ctx context.Context, l
 			log.Errorf("did not find expected prefix for bearer token in user-data secret %s", *machine.Spec.Bootstrap.DataSecretName)
 			return errors.New("did not find expected prefix for bearer token")
 		}
+		log.Info("Found Ignition endpoint token")
 		agent.Spec.IgnitionEndpointToken = (*header.Value)[len(expectedPrefix):]
 	}
 
@@ -214,6 +217,7 @@ func (r *AgentMachineReconciler) setIgnitionEndpointToken(ctx context.Context, l
 		log.WithError(agentUpdateErr).Error("failed to update Agent with ClusterDeployment ref")
 		return err
 	}
+	log.Info("Successfully updated Ignition endpoint token and MachineConfigPool")
 	return nil
 }
 


### PR DESCRIPTION
This is required in order to set the ignition endpoint details on the agent
Added logs in settingIgnitionEndpoint