### PR TITLE
Fix add agentmachine controller rbac for secret

### DIFF
--- a/controllers/agentmachine_controller.go
+++ b/controllers/agentmachine_controller.go
@@ -55,7 +55,7 @@ type AgentMachineReconciler struct {
 //+kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines,verbs=get;list;watch
-//+kubebuilder:rbac:groups=,resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
 func (r *AgentMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithFields(


### PR DESCRIPTION
adding empty string as the secret apiGroups:
//+kubebuilder:rbac:groups="",...
without it the deploy target fail with this error:
The ClusterRole "cluster-api-provider-agent-manager-role" is invalid: rules[0].apiGroups: Required value: resource rules must supply at least one api group