### PR TITLE
MGMT-8347: AgentCluster shouldn't set status.ready to true without having controlPlaneEndpoint set in the spec

### DIFF
--- a/controllers/agentcluster_controller.go
+++ b/controllers/agentcluster_controller.go
@@ -83,7 +83,10 @@ func (r *AgentClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err != nil {
 		return result, err
 	}
-
+	if !agentCluster.Spec.ControlPlaneEndpoint.IsValid() {
+		log.Info("Waiting for agentCluster controlPlaneEndpoint")
+		return ctrl.Result{RequeueAfter: defaultRequeueAfterOnError}, nil
+	}
 	// If the agentCluster has references a ClusterDeployment, sync from its status
 	return r.updateClusterStatus(ctx, log, agentCluster)
 }


### PR DESCRIPTION
 Setting ready to true without having controlPlaneEndpoint might lead to errors in CAPI
https://cluster-api.sigs.k8s.io/developer/architecture/controllers/cluster.html